### PR TITLE
Do not print to the stdout

### DIFF
--- a/src/main/kotlin/com/carterharrison/ecdsa/EcCurve.kt
+++ b/src/main/kotlin/com/carterharrison/ecdsa/EcCurve.kt
@@ -97,8 +97,6 @@ abstract class EcCurve {
 
             m = m shr 1
 
-            println(m)
-
             if (m != 0.toBigInteger()) {
                 q = PointMath.double(q)
             }


### PR DESCRIPTION
When calculating the product of  point and curve there is one `println` call which is polluting the output
when using this library as dependency.

Probably the better approach will be to add logging but I'm not sure if it is necessary.
If you think that using the proper logging is the way to go then I can change my MR to instead replace
the `println` with debug loggig.